### PR TITLE
Fixed the notification not displaying in samsung devices

### DIFF
--- a/app/src/main/java/org/oxycblt/auxio/playback/system/PlaybackNotification.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/system/PlaybackNotification.kt
@@ -89,7 +89,7 @@ class PlaybackNotification private constructor(
             setSubText(song.album.name)
         }
 
-        if (!settingsManager.colorizeNotif) {
+        if (settingsManager.colorizeNotif) {
             // loadBitmap() is concurrent, so only call back to the object calling this function when
             // the loading is over.
             loadBitmap(context, song) { bitmap ->


### PR DESCRIPTION
The problem was with the check - if(settingsManager.colorizeNotif) - it returns true so the large icon becomes null, even if there was a bitmap to load